### PR TITLE
Remove runtime dependency on Monolog, update PHP/PHPunit versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ phpunit.xml
 
 # Continuous integration artefacts
 ocular.phar
+coverage/
 coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
-    - "5.3"
     - "5.4"
     - "5.5"
     - "5.6"
-    - "7"
+    - "7.0"
+    - "7.1"
     - "hhvm"
 
 before_install:
@@ -25,5 +25,4 @@ after_script:
 matrix:
   allow_failures:
     - php:
-      - 7
       - "hhvm"

--- a/Grafizzi/Graph/Filter/AbstractCommandFilter.php
+++ b/Grafizzi/Graph/Filter/AbstractCommandFilter.php
@@ -24,7 +24,8 @@
 namespace Grafizzi\Graph\Filter;
 
 /**
- * Filters implemented as an executable file
+ * Filters implemented as an executable file.
+ *
  * - nop -p <file>+ : check and optionally pretty-print graph files
  *   - p : just check, no output
  *   - concatenate them on stdout
@@ -45,14 +46,14 @@ abstract class AbstractCommandFilter extends AbstractFilter {
    *
    * @var array
    */
-  public $commandOptions = array();
+  public $commandOptions = [];
 
   /**
    * An array of options passed on the call line of the filter command.
    *
    * @param array $args
    */
-  public function __construct(array $args = array()) {
+  public function __construct(array $args = []) {
     $this->commandOptions = $args;
   }
 
@@ -62,20 +63,20 @@ abstract class AbstractCommandFilter extends AbstractFilter {
   public function filter($input) {
     $args = '';
     foreach ($this->commandOptions as $k => $v) {
-      $args .= " $k$v";
+      $args .= ' ' . escapeshellarg("${k}${v}");
     }
 
     $command = static::$commandName . $args;
 
-    $descriptorSpec = array(
-      0 => array('pipe', 'r'),
-      1 => array('pipe', 'w'),
-      2 => array('pipe', 'w'),
-    );
-    $pipes = array();
+    $descriptorSpec = [
+      0 => ['pipe', 'r'],
+      1 => ['pipe', 'w'],
+      2 => ['pipe', 'w'],
+    ];
+    $pipes = [];
 
     // Option "bypass_shell" only works on Windows.
-    $process = proc_open($command, $descriptorSpec, $pipes, NULL, NULL, array('bypass_shell' => true));
+    $process = proc_open($command, $descriptorSpec, $pipes, NULL, NULL, ['bypass_shell' => true]);
 
     // Highly unlikely to happen outside Windows unless /bin/sh is missing.
     // Look for /bin/sh in this file (near line 810 in PHP 7.x):
@@ -86,10 +87,10 @@ abstract class AbstractCommandFilter extends AbstractFilter {
 
     fwrite($pipes[0], $input);
     fclose($pipes[0]);
-    $ret = array(
+    $ret = [
       stream_get_contents($pipes[1]),
       stream_get_contents($pipes[2]),
-    );
+    ];
     fclose($pipes[1]);
     fclose($pipes[2]);
     $status = proc_close($process);

--- a/Grafizzi/Graph/Tests/AbstractCommandFilterTest.php
+++ b/Grafizzi/Graph/Tests/AbstractCommandFilterTest.php
@@ -24,6 +24,7 @@
 namespace Grafizzi\Graph\Tests;
 
 use Grafizzi\Graph\Filter\AbstractCommandFilter;
+use PHPUnit\Framework\TestCase;
 
 require 'vendor/autoload.php';
 
@@ -32,31 +33,25 @@ class PseudoCommandFilter extends AbstractCommandFilter {}
 /**
  * Class AbstractCommandFilterTest
  */
-class AbstractCommandFilterTest extends \PHPUnit_Framework_TestCase {
+class AbstractCommandFilterTest extends TestCase {
 
   public function testFilterArguments() {
-    // echo is both a Linux, MacOS, and Windows command.
+    // echo is both a Linux, macOS, and Windows command.
     PseudoCommandFilter::$commandName = 'echo';
-    $args = array('-' => 'n', 'foo' => '=bar');
+    $args = ['+' => 'x', 'foo' => '=bar'];
     $filter = new PseudoCommandFilter($args);
     $output_lines = $filter->filter("");
     $output = implode("\n", $output_lines);
-    $this->assertEquals("foo=bar\n", $output);
+    $this->assertEquals("+x foo=bar\n\n", $output);
   }
 
+  /**
+   * @expectedException \ErrorException
+   */
   public function testUnavailableCommand() {
     // Since this is the name of this package, it is unlikely to exist.
     PseudoCommandFilter::$commandName = 'grafizzi';
     $filter = new PseudoCommandFilter();
-    try {
-      $filter->filter("");
-      $this->fail("Nonexistent command did not trigger an exception.");
-    }
-    catch (\ErrorException $e) {
-      // 'Caught expected exception for nonexistent command.
-    }
-    catch (\Exception $e) {
-      $this->fail('Caught unexpected exception for nonexistent command.');
-    }
+    $filter->filter("");
   }
 }

--- a/Grafizzi/Graph/Tests/BaseFilterTest.php
+++ b/Grafizzi/Graph/Tests/BaseFilterTest.php
@@ -23,13 +23,15 @@
 
 namespace Grafizzi\Graph\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 require 'vendor/autoload.php';
 
 /**
  *
  * @author marand
  */
-abstract class BaseFilterTest extends \PHPUnit_Framework_TestCase {
+abstract class BaseFilterTest extends TestCase {
 
   /**
    * @var \Grafizzi\Graph\Filter\FilterInterface[]

--- a/Grafizzi/Graph/Tests/BaseGraphTest.php
+++ b/Grafizzi/Graph/Tests/BaseGraphTest.php
@@ -31,6 +31,7 @@ use \Grafizzi\Graph\Graph;
 use \Monolog\Logger;
 use \Monolog\Handler\StreamHandler;
 
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 
 /**
@@ -38,7 +39,7 @@ use Pimple\Container;
  *
  * Build a graph that all other test cases will need.
  */
-abstract class BaseGraphTest extends \PHPUnit_Framework_TestCase {
+abstract class BaseGraphTest extends TestCase {
 
   /**
    *

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all:
 # Simple cleaning: delete locally generated files.
 clean:  
 	find . \( -name php_errors.log -o -name "*.dot" -o -name "*.svg" \) -delete
-	rm -fr doxygen 
+	rm -fr coverage* doxygen 
 
 docs:
 	doxygen Grafizzi.dox

--- a/README.md
+++ b/README.md
@@ -11,13 +11,37 @@ Welcome to Grafizzi, a PHP wrapper for AT&T GraphViz.
 
 # 1) Using Grafizzi in your PHP GraphViz projects
 
-Grafizzi is available from https://github.com/FGM/grafizzi and declared
-on http://packagist.org, making it available to your projects using Composer.
+## Installing it in your project.
 
-Just declare `osinet/grafizzi: *` in the `require` section of your
-`composer.json` and Composer will fetch Grafizzi and include it in the
-autoloader map it will generate for your project.
+```bash
+$ composer require osinet/grafizzi
+```
 
+## Generating graphs with Grafizzi
+
+1. Create a Pimple instance, passing it an instance for your PSR/3 logger of choice
+  (e.g. [Monolog]) in the `logger` key, and possibly other arguments like 
+  `directed` to specify if you want to build a directed graph.
+1. Create a `Graph` instance, passing it the container.
+1. Add `Subgraph`, `Node` and `Edge` instances to the graph using the 
+  `addChild()` method. Each of these take the container and an array of 
+  `Attribute` instances in their constructor, or you can add them using 
+  `setAttribute()` after construction. Attribute instances are reusable on
+  multiple elements.
+1. Invoke the `build()` method on the graph instance to obtain a string 
+   containing your Graphviz dot-file, which you can then output to a file or
+   pipe to `dot`, `neato` or your Graphviz command of choice.
+1. Optional: use a chain of `Filter` instances to filter the result, for example
+   to run Graphviz from your PHP script (`DotFilter`), or "tee" it between a
+   filter pipe and a string (`StringFilter`).
+   
+You can take inspiration from the examples provided in the `app/` directory:
+
+* `app/hello_node.php` builds a minimal graph showing a lot of logging
+* `app/grafizzi.php` builds a graph for the Grafizzi hierarchy of `Filter` 
+  classes.
+  
+[Monolog]: https://github.com/Seldaek/monolog
 
 # 2) Working on Grafizzi itself
 
@@ -43,7 +67,7 @@ Then run:
 
     php composer.phar install
 
-Note that Grafizzi is available for PHP &ge; 5.3, including 7.x.
+Note that Grafizzi is available for PHP &ge; 5.4, including 7.1.x and HHVM.
 
 
 #### c) Check your System Configuration
@@ -100,8 +124,8 @@ your `vendor` folder.
 
 ### Cleaning up
 
-You can remove php_error.log, the generated doxygen docs directory, and many
-stray generated files by running:
+You can remove php_error.log, the generated doxygen docs directory, the 
+generated coverage reports, and many stray generated files by running:
 
     make clean
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": ">=4.6|>=5.4",
+    "phpunit/phpunit": "^4.8|^6.0",
     "monolog/monolog": "^1.22"
   },
 

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,15 @@
   "name": "osinet/grafizzi",
 
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.4.0",
 
-    "monolog/monolog": "~1",
-    "pimple/pimple": "~3"
+    "pimple/pimple": "~3",
+    "psr/log": "^1.0"
   },
 
   "require-dev": {
-    "phpunit/phpunit": ">=4.6|>=5.4"
+    "phpunit/phpunit": ">=4.6|>=5.4",
+    "monolog/monolog": "^1.22"
   },
 
   "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,18 +9,22 @@
   convertWarningsToExceptions="true"
   forceCoversAnnotation="false"
   mapTestClassNameToCoveredClassName="false"
-  printerClass="PHPUnit_TextUI_ResultPrinter"
+  printerFile="phpunit/src/TextUI/ResultPrinter.php"
   processIsolation="false"
   stopOnError="false"
   stopOnFailure="false"
   stopOnIncomplete="false"
   stopOnSkipped="false"
-  testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+  testSuiteLoaderFile="phpunit/src/Runner/StandardTestSuiteLoader.php"
   verbose="true">
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">
       <directory>Grafizzi/</directory>
+      <exclude>
+        <directory suffix="Test.php">./</directory>
+        <directory suffix="TestsSuite.php">./</directory>
+      </exclude>
       </whitelist>
     </filter>
 


### PR DESCRIPTION
- Monolog still used for dev to have an implementation available for the demos
- Upgrade requirements to PHP5.4